### PR TITLE
Service-to-Service (S2S) authentication

### DIFF
--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
@@ -180,7 +180,24 @@ public class SimulationConfig {
   private String getAuthClientCode() {
     return properties.getProperty(environment + ".oauth.clientCode");
   }
-  
+
+  private String getServiceAuthClientId() {
+    return properties.getProperty(environment + ".oauth.service.clientId");
+  }
+
+  private String getServiceAuthClientCode() {
+    return properties.getProperty(environment + ".oauth.service.clientCode");
+  }
+
+  private String getServiceAuthGrantType() {
+    return properties.getProperty(environment + ".oauth.service.grantType");
+  }
+
+  private String getServiceAuthClientSecret() {
+    return properties.getProperty(environment + ".oauth.service.clientSecret");
+  }
+
+
   private String getEndpoint() {
     return properties.getProperty(environment + ".endpoint");
   }
@@ -299,5 +316,21 @@ public class SimulationConfig {
 
   public static String getGrafanaPassword() {
     return instance.grafanaPassword();
+  }
+
+  public static String getServiceClientId() {
+    return instance.getServiceAuthClientId();
+  }
+
+  public static String getServiceClientCode() {
+    return instance.getServiceAuthClientCode();
+  }
+
+  public static String getServiceGrantType() {
+    return instance.getServiceAuthGrantType();
+  }
+
+  public static String getServiceClientSecret() {
+    return instance.getServiceAuthClientSecret();
   }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  *
  * @author Erhan Bagdemir
  * @see SimulationImpl
- * @since 1.0
+ * @since 1.0.0
  */
 public class SimulationConfig {
 
@@ -56,9 +56,8 @@ public class SimulationConfig {
     this.properties = new Properties();
     this.environment = environment.toString();
     this.simulationId = Optional
-            .ofNullable(System.getenv().get(SIM_ID))
-            .orElse(UUID.randomUUID().toString());
-
+        .ofNullable(System.getenv().get(SIM_ID))
+        .orElse(UUID.randomUUID().toString());
     loadConfig(path);
   }
 
@@ -74,7 +73,7 @@ public class SimulationConfig {
 
   private void loadConfig(final String path) {
 
-    try(var is = new ConfigResource(path).getInputStream()) {
+    try (var is = new ConfigResource(path).getInputStream()) {
       properties.load(is);
 
       var propsValidator = new PropsValidatorImpl();
@@ -181,12 +180,24 @@ public class SimulationConfig {
     return properties.getProperty(environment + ".oauth.clientCode");
   }
 
+  private String getServiceAuthEnabled() {
+    return properties.getProperty(environment + ".oauth.service.authentication");
+  }
+
   private String getServiceAuthClientId() {
     return properties.getProperty(environment + ".oauth.service.clientId");
   }
 
   private String getServiceAuthClientCode() {
     return properties.getProperty(environment + ".oauth.service.clientCode");
+  }
+
+  private String getAuthBearerType() {
+    return properties.getProperty(environment + ".oauth.bearer");
+  }
+
+  private String getAuthHeaderName() {
+    return properties.getProperty(environment + ".oauth.headerName");
   }
 
   private String getServiceAuthGrantType() {
@@ -332,5 +343,17 @@ public class SimulationConfig {
 
   public static String getServiceClientSecret() {
     return instance.getServiceAuthClientSecret();
+  }
+
+  public static boolean isServiceAuthenticationEnabled() {
+    return "true".equalsIgnoreCase(instance.getServiceAuthEnabled());
+  }
+
+  public static String getBearerType() {
+    return instance.getAuthBearerType();
+  }
+
+  public static String getHeaderName() {
+    return instance.getAuthHeaderName();
   }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationJobsScannerImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationJobsScannerImpl.java
@@ -73,8 +73,7 @@ public class SimulationJobsScannerImpl implements SimulationJobsScanner {
 
     return Arrays.stream(inPackages)
         .map(p -> p.replace(DOT, File.separator))
-        .flatMap(p -> scanBenchmarkClassesIn(p).stream()
-            .filter(a -> forSimulation.equals(getSimulationName(a))))
+        .flatMap(p -> scanBenchmarkClassesIn(p).stream().filter(a -> forSimulation.equals(getSimulationName(a))))
         .map(this::createBenchmarkJob)
         .collect(toList());
   }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/UnknownTokenTypeException.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/UnknownTokenTypeException.java
@@ -1,0 +1,8 @@
+package io.ryos.rhino.sdk.exceptions;
+
+public class UnknownTokenTypeException extends RuntimeException {
+
+  public UnknownTokenTypeException(final String message) {
+    super(message);
+  }
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthService.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthService.java
@@ -1,0 +1,73 @@
+package io.ryos.rhino.sdk.users.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a service of the user. If the service exists, then requests against the web
+ * service being tests will be made with both user and service token.
+ * <p>
+ *
+ * @author Erhan Bagdemir
+ * @since 1.6.0
+ */
+public class OAuthService {
+
+  private String clientId;
+  private String clientSecret;
+  private String grantType;
+  private String clientCode;
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  public void setClientId(final String clientId) {
+    this.clientId = clientId;
+  }
+
+  public void setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public void setGrantType(final String grantType) {
+    this.grantType = grantType;
+  }
+
+  public void setClientCode(final String clientCode) {
+    this.clientCode = clientCode;
+  }
+
+  public void setAccessToken(final String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public void setRefreshToken(final String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public String getGrantType() {
+    return grantType;
+  }
+
+  public String getClientCode() {
+    return clientCode;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthUser.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthUser.java
@@ -51,4 +51,10 @@ public interface OAuthUser extends User {
    * @return Client id.
    */
   String getClientId();
+
+  /**
+   * OAuth Service.
+   * @return  OAuth Service.
+   */
+  OAuthService getOAuthService();
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthUserImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/data/OAuthUserImpl.java
@@ -26,10 +26,12 @@ public class OAuthUserImpl extends UserImpl implements OAuthUser {
 
   private String accessToken;
   private String refreshToken;
+  private OAuthService service;
   private String scope;
   private String clientId;
 
-  public OAuthUserImpl(final String user,
+  public OAuthUserImpl(final OAuthService service,
+      final String user,
       final String password,
       final String accessToken,
       final String refreshToken,
@@ -40,6 +42,7 @@ public class OAuthUserImpl extends UserImpl implements OAuthUser {
 
     super(user, password, id, scope, region);
 
+    this.service = service;
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.clientId = clientId;
@@ -80,6 +83,11 @@ public class OAuthUserImpl extends UserImpl implements OAuthUser {
   @Override
   public String getClientId() {
     return clientId;
+  }
+
+  @Override
+  public OAuthService getOAuthService() {
+    return service;
   }
 
   @Override

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/Authenticator.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/Authenticator.java
@@ -1,0 +1,26 @@
+package io.ryos.rhino.sdk.users.repositories;
+
+/**
+ * Generic authenticator authenticates an entity against an authorization server. The entity can
+ * be a user or a service.
+ * <p>
+ *
+ * @param <T> The entity type being authenticated.
+ * @param <R> Return type with authentication tokens. The return type is to be a sub type of the
+ * entity.
+ * @author Erhan Bagdemir
+ * @since 1.6.0
+ */
+public interface Authenticator<T, R extends T> {
+
+  /**
+   * Authenticates an entity against an authorization server. The entity can be a user or a
+   * service.
+   * <p>
+   *
+   * @param entity The entity to be authenticated.
+   * @return Authenticated entity type which has is-a relationship to the entity type being
+   * authenticated.
+   */
+  R authenticate(T entity);
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/Authenticator.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/Authenticator.java
@@ -1,10 +1,9 @@
 package io.ryos.rhino.sdk.users.repositories;
 
-import io.ryos.rhino.sdk.users.data.OAuthUser;
 import io.ryos.rhino.sdk.users.data.User;
 
 /**
- * TODO
+ * Authenticator for users.
  * <p>
  *
  * @author Erhan Bagdemir
@@ -12,6 +11,14 @@ import io.ryos.rhino.sdk.users.data.User;
  */
 public interface Authenticator<T extends User> {
 
+  /**
+   * Authenticates a user against an authorization server.
+   * <p>
+   *
+   * @param user The user to be authenticated.
+   * @return Authenticated user type. In OAuth 2.0 user context, it is a
+   * {@link io.ryos.rhino.sdk.users.data.OAuthUser}.
+   */
   T authenticate(User user);
 
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthServiceAuthenticatorImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthServiceAuthenticatorImpl.java
@@ -1,0 +1,81 @@
+package io.ryos.rhino.sdk.users.repositories;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ryos.rhino.sdk.SimulationConfig;
+import io.ryos.rhino.sdk.exceptions.ExceptionUtils;
+import io.ryos.rhino.sdk.exceptions.UserLoginException;
+import io.ryos.rhino.sdk.users.data.OAuthService;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.Response.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OAuthServiceAuthenticatorImpl implements ServiceAuthenticator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OAuthServiceAuthenticatorImpl.class);
+
+  private static final String CLIENT_ID = "client_id";
+  private static final String CLIENT_SECRET = "client_secret";
+  private static final String GRANT_TYPE = "grant_type";
+  private static final String CODE = "code";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public OAuthService authenticate(final OAuthService service) {
+
+    try {
+
+      var form = new Form();
+
+      if (SimulationConfig.getClientId() != null) {
+        form.param(CLIENT_ID, SimulationConfig.getServiceClientId());
+      }
+
+      if (SimulationConfig.getClientSecret() != null) {
+        form.param(CLIENT_SECRET, SimulationConfig.getServiceClientSecret());
+      }
+
+      if (SimulationConfig.getGrantType() != null) {
+        form.param(GRANT_TYPE, SimulationConfig.getServiceGrantType());
+      }
+
+      if (SimulationConfig.getClientCode() != null) {
+        form.param(CODE, SimulationConfig.getServiceClientCode());
+      }
+
+      var client = ClientBuilder.newClient();
+      var response = client
+          .target(SimulationConfig.getAuthServer())
+          .request()
+          .post(Entity.form(form));
+
+      if (response.getStatus() != Status.OK.getStatusCode()) {
+        LOG.info("Cannot login the service, status={} message={}", response.getStatus(), response.readEntity(String.class));
+        return null;
+      }
+
+      var responseInString = response.readEntity(String.class);
+      LOG.debug(responseInString);
+
+      return mapToEntity(responseInString);
+    } catch (Exception e) {
+      ExceptionUtils.rethrow(e, UserLoginException.class, "Login failed.");
+    }
+
+    return null;
+  }
+
+  private OAuthService mapToEntity(final String s) {
+    final OAuthService o;
+    try {
+      o = objectMapper.readValue(s, OAuthService.class);
+    } catch (Exception e) {
+      throw new RuntimeException("Cannot map authorization server response to entity type: " + OAuthService.class.getName(),
+          e);
+    }
+    return o;
+  }
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserAuthenticatorImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserAuthenticatorImpl.java
@@ -20,12 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ryos.rhino.sdk.SimulationConfig;
 import io.ryos.rhino.sdk.exceptions.ExceptionUtils;
 import io.ryos.rhino.sdk.exceptions.UserLoginException;
-import io.ryos.rhino.sdk.runners.DefaultSimulationRunner;
 import io.ryos.rhino.sdk.users.OAuthEntity;
 import io.ryos.rhino.sdk.users.data.OAuthUser;
 import io.ryos.rhino.sdk.users.data.OAuthUserImpl;
 import io.ryos.rhino.sdk.users.data.User;
-import java.util.Optional;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
@@ -34,14 +32,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link Authenticator} implementation for OAuth 2.0.
+ * {@link UserAuthenticator} implementation for OAuth 2.0.
  * <p>
  *
  * @author Erhan Bagdemir
  * @since 1.1.0
  */
-public class OAuthAuthenticatorImpl implements Authenticator<OAuthUser> {
-  private static final Logger LOG = LoggerFactory.getLogger(OAuthAuthenticatorImpl.class);
+public class OAuthUserAuthenticatorImpl implements UserAuthenticator<OAuthUser> {
+  private static final Logger LOG = LoggerFactory.getLogger(OAuthUserAuthenticatorImpl.class);
 
   private static final String CLIENT_ID = "client_id";
   private static final String CLIENT_SECRET = "client_secret";

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserRepositoryImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserRepositoryImpl.java
@@ -28,7 +28,6 @@ public class OAuthUserRepositoryImpl implements UserRepository<UserSession> {
 
   private final long loginDelay;
   private final OAuthUserAuthenticatorImpl authenticator;
-
   private final UserSource userSource;
 
   OAuthUserRepositoryImpl(final UserSource userSource, long loginDelay) {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserRepositoryImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/OAuthUserRepositoryImpl.java
@@ -27,13 +27,13 @@ import java.util.Objects;
 public class OAuthUserRepositoryImpl implements UserRepository<UserSession> {
 
   private final long loginDelay;
-  private final OAuthAuthenticatorImpl authenticator;
+  private final OAuthUserAuthenticatorImpl authenticator;
 
   private final UserSource userSource;
 
   OAuthUserRepositoryImpl(final UserSource userSource, long loginDelay) {
     this.userSource = Objects.requireNonNull(userSource);
-    this.authenticator = new OAuthAuthenticatorImpl();
+    this.authenticator = new OAuthUserAuthenticatorImpl();
     this.loginDelay = loginDelay;
   }
 

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/ServiceAuthenticator.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/ServiceAuthenticator.java
@@ -1,0 +1,15 @@
+package io.ryos.rhino.sdk.users.repositories;
+
+import io.ryos.rhino.sdk.users.data.OAuthService;
+
+public interface ServiceAuthenticator extends Authenticator<OAuthService, OAuthService> {
+
+  /**
+   * Authenticates a service against an authorization server.
+   * <p>
+   *
+   * @param user The service to be authenticated.
+   * @return Authenticated service type.
+   */
+  OAuthService authenticate(OAuthService user);
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/UserAuthenticator.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/UserAuthenticator.java
@@ -9,7 +9,7 @@ import io.ryos.rhino.sdk.users.data.User;
  * @author Erhan Bagdemir
  * @since 1.1.0
  */
-public interface UserAuthenticator<T extends User> {
+public interface UserAuthenticator<T extends User> extends Authenticator<User, T> {
 
   /**
    * Authenticates a user against an authorization server.
@@ -20,5 +20,4 @@ public interface UserAuthenticator<T extends User> {
    * {@link io.ryos.rhino.sdk.users.data.OAuthUser}.
    */
   T authenticate(User user);
-
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/UserAuthenticator.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/users/repositories/UserAuthenticator.java
@@ -9,7 +9,7 @@ import io.ryos.rhino.sdk.users.data.User;
  * @author Erhan Bagdemir
  * @since 1.1.0
  */
-public interface Authenticator<T extends User> {
+public interface UserAuthenticator<T extends User> {
 
   /**
    * Authenticates a user against an authorization server.

--- a/rhino-core/src/test/resources/rhino.properties
+++ b/rhino-core/src/test/resources/rhino.properties
@@ -4,10 +4,18 @@ dev.users.file=classpath:///test_users.csv
 dev.users.source=file
 
 dev.oauth.endpoint=http://localhost:8089/token
-dev.oauth.clientId=
-dev.oauth.clientSecret=
+dev.oauth.clientId=TestClient
+dev.oauth.clientSecret=123-567
 dev.oauth.apiKey=YourKey
-dev.oauth.grantType=
+dev.oauth.grantType=password
+dev.oauth.service.authentication=true
+dev.oauth.service.clientId=TestService
+dev.oauth.service.clientSecret=123-
+dev.oauth.service.grantType=authorization_code
+dev.oauth.service.clientCode=eyJ4NXUiO123345
+
+dev.oauth.bearer=service
+dev.oauth.headerName=X-User-Token
 
 db.influx.url=http://localhost:8086
 db.influx.dbName=rhino


### PR DESCRIPTION
@luxmeter FYI. 

With this PR the framework supports service tokens in HTTP request headers along with user token. The Bearer token is to be sent as Authorization header in requests. 
If service token is enabled, the test developer can choose which token is used as bearer token between user and service token in Authorization header, and he/she can provide with an alternative header name for non-bearer (if the user token is to be sent in Authorization header, the header name for service token might be "X-Service-Token"). 

Fixes #55 