### PR TITLE
DSL Support in Prepare and Cleanup steps.

### DIFF
--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
@@ -85,6 +85,17 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
     this(client, eventDispatcher, null);
   }
 
+  /**
+   * Specification materializer translates the specifications into reactor implementations.
+   * <p>
+   *
+   * @param client Async HTTP client instance.
+   */
+  public HttpSpecMaterializer(final AsyncHttpClient client) {
+    this(client, null, null);
+  }
+
+
   public Mono<UserSession> materialize(final HttpSpec spec, final UserSession userSession) {
 
     if (conditionalSpec != null && !conditionalSpec.test(userSession)) {
@@ -97,15 +108,12 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
         eventDispatcher,
         spec.isMeasurementEnabled());
 
-    var responseMono = Mono
-        .just(userSession)
-        .flatMap(
-            s -> Mono.fromFuture(client.executeRequest(buildRequest(spec, s), httpSpecAsyncHandler)
+    var responseMono = Mono.just(userSession)
+        .flatMap(s -> Mono.fromCompletionStage(client.executeRequest(buildRequest(spec, s), httpSpecAsyncHandler)
                 .toCompletableFuture()));
 
     var retriableMono = Optional.ofNullable(spec.getRetryInfo())
-        .map(retryInfo ->
-            responseMono
+        .map(retryInfo -> responseMono
                 .map(HttpResponse::new)
                 .map(hr -> isRetriable(retryInfo, hr))
                 .retryWhen(companion -> companion

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
@@ -84,18 +84,7 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
       final EventDispatcher eventDispatcher) {
     this(client, eventDispatcher, null);
   }
-
-  /**
-   * Specification materializer translates the specifications into reactor implementations.
-   * <p>
-   *
-   * @param client Async HTTP client instance.
-   */
-  public HttpSpecMaterializer(final AsyncHttpClient client) {
-    this(client, null, null);
-  }
-
-
+  
   public Mono<UserSession> materialize(final HttpSpec spec, final UserSession userSession) {
 
     if (conditionalSpec != null && !conditionalSpec.test(userSession)) {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/NoSpecDefinedException.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/NoSpecDefinedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Ryos.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ryos.rhino.sdk.exceptions;
+
+/**
+ * @author Erhan Bagdemir
+ * @since 1.6.0
+ */
+public class NoSpecDefinedException extends RuntimeException {
+
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/NoSpecDefinedException.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/NoSpecDefinedException.java
@@ -17,9 +17,16 @@
 package io.ryos.rhino.sdk.exceptions;
 
 /**
+ * The exception is thrown if there is no spec defined in {@link io.ryos.rhino.sdk.dsl.LoadDsl}.
+ * The pipeline will then be terminated.
+ * <p>
+ *
  * @author Erhan Bagdemir
  * @since 1.6.0
  */
 public class NoSpecDefinedException extends RuntimeException {
 
+  public NoSpecDefinedException(String message) {
+    super(message);
+  }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/StdoutReporter.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/StdoutReporter.java
@@ -114,9 +114,9 @@ public class StdoutReporter extends AbstractActor {
       return;
     }
 
+    flushReport(endEvent);
     this.receivedTerminationEvent = true;
     this.timer.cancel();
-    flushReport(endEvent);
     sender().tell(MSG_OK, self());
   }
 

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/AbstractSimulationRunner.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/AbstractSimulationRunner.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Ryos.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ryos.rhino.sdk.runners;
+
+import io.ryos.rhino.sdk.SimulationConfig;
+import io.ryos.rhino.sdk.SimulationMetadata;
+import io.ryos.rhino.sdk.data.Scenario;
+import io.ryos.rhino.sdk.monitoring.GrafanaGateway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO
+ * <p>
+ *
+ * @author Erhan Bagdemir
+ * @since 1.1.0
+ */
+public abstract class AbstractSimulationRunner implements SimulationRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractSimulationRunner.class);
+
+  private final SimulationMetadata simulationMetadata;
+
+  public AbstractSimulationRunner(SimulationMetadata simulationMetadata) {
+    this.simulationMetadata = simulationMetadata;
+  }
+
+  protected void setUpGrafanaDashboard() {
+    LOG.info("Grafana is enabled. Creating dashboard: " + SimulationConfig.getSimulationId());
+    new GrafanaGateway(simulationMetadata.getGrafanaInfo())
+        .setUpDashboard(SimulationConfig.getSimulationId(),
+            simulationMetadata.getScenarios()
+                .stream()
+                .map(Scenario::getDescription)
+                .toArray(String[]::new));
+  }
+
+  public SimulationMetadata getSimulationMetadata() {
+    return simulationMetadata;
+  }
+}

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/DefaultSimulationRunner.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/DefaultSimulationRunner.java
@@ -153,16 +153,6 @@ public class DefaultSimulationRunner extends AbstractSimulationRunner {
     }
   }
 
-  private void setUpGrafanaDashboard() {
-    LOG.info("Grafana is enabled. Creating dashboard: " + SimulationConfig.getSimulationId());
-    new GrafanaGateway(getSimulationMetadata().getGrafanaInfo())
-        .setUpDashboard(SimulationConfig.getSimulationId(),
-            getSimulationMetadata().getScenarios()
-                .stream()
-                .map(Scenario::getDescription)
-                .toArray(String[]::new));
-  }
-
   private void await() {
     synchronized (this) {
       try {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/ReactiveHttpSimulationRunner.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/ReactiveHttpSimulationRunner.java
@@ -316,7 +316,7 @@ public class ReactiveHttpSimulationRunner implements SimulationRunner {
 
     var specIt = dsl.getSpecs().iterator();
     if (!specIt.hasNext()) {
-      throw new NoSpecDefinedException();
+      throw new NoSpecDefinedException(dsl.getName());
     }
     var acc = materialize(specIt.next(), client, session);
     while (specIt.hasNext()) {

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/BlockingJerseyClientLoadTestSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/BlockingJerseyClientLoadTestSimulation.java
@@ -50,9 +50,6 @@ public class BlockingJerseyClientLoadTestSimulation {
 
   @Scenario(name = "Health")
   public void performHealth(Measurement measurement) {
-
-    System.out.println("Perform");
-
     var response = client
         .target(TARGET)
         .request()

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/FluxTimingsTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/FluxTimingsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Ryos.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ryos.rhino.sdk;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.ryos.rhino.sdk.dsl.HttpSpecMaterializer;
+import io.ryos.rhino.sdk.runners.EventDispatcher;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.filter.ThrottleRequestFilter;
+import org.junit.Rule;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class FluxTimingsTest {
+
+  public static final String TARGET = "http://localhost:8089/api/files";
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(options().port(8089)
+      .jettyAcceptors(2)
+      .jettyAcceptQueueSize(100)
+      .containerThreads(100));
+
+  @Test
+  public void testFluxTiming() {
+
+    var httpClientConfig = Dsl.config()
+        .setKeepAlive(true)
+        .setMaxConnections(1)
+        .setConnectTimeout(60000)
+        .setHandshakeTimeout(60000)
+        .setReadTimeout(4000)
+        .addRequestFilter(new ThrottleRequestFilter(1))
+        .build();
+
+    var client = Dsl.asyncHttpClient(httpClientConfig);
+
+    stubFor(WireMock.get(urlEqualTo("/api/files"))
+        .willReturn(aResponse()
+            .withFixedDelay(2000)
+            .withStatus(200)));
+
+    System.out.println("Before flux");
+
+    Flux.fromArray(new Integer [] { 1, 2, 3 })
+        .flatMap(i ->
+            Mono.fromCompletionStage(client.executeRequest(Dsl.get(TARGET).build()).toCompletableFuture())
+                .doOnNext(r -> System.out.println(r.getStatusCode())))
+        .doOnComplete(() -> {
+          System.out.println("completed");
+        })
+        .blockLast();
+
+    System.out.println("After flux");
+  }
+}

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveBasicHttpGetSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveBasicHttpGetSimulation.java
@@ -2,6 +2,7 @@ package io.ryos.rhino.sdk;
 
 import static io.ryos.rhino.sdk.specs.HttpSpec.from;
 import static io.ryos.rhino.sdk.specs.Spec.http;
+import static io.ryos.rhino.sdk.specs.Spec.some;
 
 import io.ryos.rhino.sdk.annotations.CleanUp;
 import io.ryos.rhino.sdk.annotations.Dsl;
@@ -9,11 +10,13 @@ import io.ryos.rhino.sdk.annotations.Prepare;
 import io.ryos.rhino.sdk.annotations.Runner;
 import io.ryos.rhino.sdk.annotations.Simulation;
 import io.ryos.rhino.sdk.annotations.UserRepository;
+import io.ryos.rhino.sdk.data.UserSession;
 import io.ryos.rhino.sdk.dsl.LoadDsl;
 import io.ryos.rhino.sdk.dsl.Start;
 import io.ryos.rhino.sdk.runners.ReactiveHttpSimulationRunner;
 import io.ryos.rhino.sdk.users.repositories.OAuthUserRepositoryFactory;
 import java.util.UUID;
+import org.asynchttpclient.Response;
 
 @Simulation(name = "Reactive Test", durationInMins = 1)
 @Runner(clazz = ReactiveHttpSimulationRunner.class)
@@ -24,6 +27,23 @@ public class ReactiveBasicHttpGetSimulation {
   private static final String X_REQUEST_ID = "X-Request-Id";
   private static final String X_API_KEY = "X-Api-Key";
 
+  @Prepare
+  public static LoadDsl prepare(UserSession userSession) {
+    return Start.dsl()
+        .run(http("Prepare")
+            .header(c -> from(X_REQUEST_ID, "Rhino-" + UUID.randomUUID().toString()))
+            .header(X_API_KEY, SimulationConfig.getApiKey())
+            .auth()
+            .endpoint(FILES_ENDPOINT)
+            .get()
+            .saveTo("result"))
+        .run(some("Status").as((u, s) -> {
+          u.<Response>get("result")
+              .ifPresent(httpResponse -> System.out.println(httpResponse.getStatusCode()));
+          return u;
+        }));
+  }
+
   @Dsl(name = "Shop Benchmarks")
   public LoadDsl singleTestDsl() {
     return Start.dsl()
@@ -32,18 +52,23 @@ public class ReactiveBasicHttpGetSimulation {
             .header(X_API_KEY, SimulationConfig.getApiKey())
             .auth()
             .endpoint(FILES_ENDPOINT)
-            .get()
-            .saveTo("result")
-            .noMeasurement());
-  }
-
-  @Prepare
-  public void prepare() {
-    System.out.println("Preparation in progress.");
+            .get());
   }
 
   @CleanUp
-  public void cleanUp() {
-    System.out.println("Clean-up in progress.");
+  public static LoadDsl cleanUp(UserSession userSession) {
+    return Start.dsl()
+        .run(http("Clean-up")
+            .header(c -> from(X_REQUEST_ID, "Rhino-" + UUID.randomUUID().toString()))
+            .header(X_API_KEY, SimulationConfig.getApiKey())
+            .auth()
+            .endpoint(FILES_ENDPOINT)
+            .get()
+            .saveTo("result"))
+        .run(some("Status").as((u, s) -> {
+          u.<Response>get("result")
+              .ifPresent(httpResponse -> System.out.println(httpResponse.getStatusCode()));
+          return u;
+        }));
   }
 }

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveBasicHttpGetTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveBasicHttpGetTest.java
@@ -24,7 +24,7 @@ public class ReactiveBasicHttpGetTest {
       .containerThreads(100));
 
   @Test
-  public void testReactiveBasicHttp() {
+  public void testReactiveBasicHttp() throws InterruptedException {
     stubFor(WireMock.post(urlEqualTo("/token"))
         .willReturn(aResponse()
             .withStatus(200)
@@ -35,6 +35,14 @@ public class ReactiveBasicHttpGetTest {
             .withFixedDelay(800)
             .withStatus(200)));
 
+    stubFor(WireMock.get(urlEqualTo("/api/prepare"))
+        .willReturn(aResponse()
+            .withFixedDelay(800)
+            .withStatus(200)));
+
+
     Simulation.create(PROPERTIES_FILE, SIM_NAME).start();
+
+    Thread.sleep(5000L);
   }
 }


### PR DESCRIPTION
@luxmeter 

* wait()/notify() is replaced with more modern concurrency primitives like Locks and Conditionals. 
* DSL support in prepare and cleanup steps. 
* Execution sequence, prepare, simulation and clean up synchronised by locks. 

Fixes https://github.com/ryos-io/Rhino/issues/100
