### PR TITLE
Cumulative measurement in Retry scenarios 

### DIFF
--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/GrafanaInfo.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/GrafanaInfo.java
@@ -19,7 +19,7 @@ package io.ryos.rhino.sdk;
 import io.ryos.rhino.sdk.monitoring.GrafanaDashboard;
 
 /**
- * TODO
+ * Grafana integration entity.
  * <p>
  *
  * @author Erhan Bagdemir
@@ -30,8 +30,7 @@ public class GrafanaInfo {
   private Class<? extends GrafanaDashboard> dashboard;
   private String pathToTemplate;
 
-  public GrafanaInfo(
-      Class<? extends GrafanaDashboard> dashboard, String pathToTemplate) {
+  GrafanaInfo(Class<? extends GrafanaDashboard> dashboard, String pathToTemplate) {
     this.dashboard = dashboard;
     this.pathToTemplate = pathToTemplate;
   }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/SimulationConfig.java
@@ -142,7 +142,7 @@ public class SimulationConfig {
 
   private String getConfigHttpReadTimeout() {
     return properties.getProperty("http.readTimeout",
-        "5000");
+        "15000");
   }
 
   private String getConfigHttpHandshakeTimeout() {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpSpecMaterializer.java
@@ -24,6 +24,7 @@ import static org.asynchttpclient.Dsl.put;
 
 import io.ryos.rhino.sdk.SimulationConfig;
 import io.ryos.rhino.sdk.data.UserSession;
+import io.ryos.rhino.sdk.exceptions.RetryFailedException;
 import io.ryos.rhino.sdk.exceptions.RetryableOperationException;
 import io.ryos.rhino.sdk.exceptions.UnknownTokenTypeException;
 import io.ryos.rhino.sdk.runners.EventDispatcher;
@@ -84,42 +85,39 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
       final EventDispatcher eventDispatcher) {
     this(client, eventDispatcher, null);
   }
-  
+
   public Mono<UserSession> materialize(final HttpSpec spec, final UserSession userSession) {
 
     if (conditionalSpec != null && !conditionalSpec.test(userSession)) {
       return Mono.just(userSession);
     }
 
-    var httpSpecAsyncHandler = new HttpSpecAsyncHandler(userSession.getUser().getId(),
-        spec.getTestName(),
-        spec.getMeasurementPoint(),
-        eventDispatcher,
-        spec.isMeasurementEnabled());
-
+    var httpSpecAsyncHandler = new HttpSpecAsyncHandler(userSession, spec, eventDispatcher);
     var responseMono = Mono.just(userSession)
         .flatMap(s -> Mono.fromCompletionStage(client.executeRequest(buildRequest(spec, s), httpSpecAsyncHandler)
                 .toCompletableFuture()));
 
     var retriableMono = Optional.ofNullable(spec.getRetryInfo())
-        .map(retryInfo -> responseMono
-                .map(HttpResponse::new)
-                .map(hr -> isRetriable(retryInfo, hr))
-                .retryWhen(companion -> companion
-                    .zipWith(Flux.range(1, retryInfo.getNumOfRetries()), (error, index) -> {
-                      if (index < retryInfo.getNumOfRetries()
-                          && error instanceof RetryableOperationException) {
-                        return index;
-                      } else {
-                        throw Exceptions.propagate(error);
-                      }
-                    })))
+        .map(retryInfo -> responseMono.map(HttpResponse::new)
+            .map(hr -> isRetriable(retryInfo, hr))
+            .retryWhen(companion -> companion
+                .zipWith(Flux.range(1, retryInfo.getNumOfRetries() + 3), (error, index) -> {
+                  if (index < retryInfo.getNumOfRetries() && error instanceof RetryableOperationException) {
+                    return index;
+                  } else {
+                    throw Exceptions.propagate(new RetryFailedException(error));
+                  }
+                })))
         .orElse(responseMono);
 
     return retriableMono.map(response -> (UserSession) userSession
-        .add(Optional.ofNullable(spec.getResponseKey()).orElse("result"),
-            response))
-        .onErrorResume(e -> Mono.empty())
+        .add(Optional.ofNullable(spec.getResponseKey()).orElse("result"), response))
+        .onErrorResume(error -> {
+          if (error instanceof RetryFailedException && spec.isCumulativeMeasurement()) {
+            httpSpecAsyncHandler.completeMeasurement();
+          }
+          return Mono.empty();
+        })
         .doOnError(t -> LOG.error("Http Client Error", t));
   }
 
@@ -172,28 +170,33 @@ public class HttpSpecMaterializer implements SpecMaterializer<HttpSpec, UserSess
     }
 
     if (httpSpec.isAuth()) {
-      var user = userSession.getUser();
-      if (user instanceof OAuthUser) {
-        var authService = ((OAuthUser) user).getOAuthService();
-        if (SimulationConfig.isServiceAuthenticationEnabled()) {
-          var serviceAccessToken = authService.getAccessToken();
-          var userToken = ((OAuthUser) user).getAccessToken();
-          if (USER.equals(SimulationConfig.getBearerType())) {
-            builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + userToken);
-            builder = builder.addHeader(SimulationConfig.getHeaderName(), serviceAccessToken);
-          } else if (SERVICE.equals(SimulationConfig.getBearerType())) {
-            builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + serviceAccessToken);
-            builder = builder.addHeader(SimulationConfig.getHeaderName(), userToken);
-          } else {
-            throw new UnknownTokenTypeException(SimulationConfig.getBearerType());
-          }
-        } else {
-          var token = ((OAuthUser) user).getAccessToken();
-          builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + token);
-        }
-      }
+      builder = handleAuth(userSession, builder);
     }
 
+    return builder;
+  }
+
+  private RequestBuilder handleAuth(UserSession userSession, RequestBuilder builder) {
+    var user = userSession.getUser();
+    if (user instanceof OAuthUser) {
+      var authService = ((OAuthUser) user).getOAuthService();
+      if (SimulationConfig.isServiceAuthenticationEnabled()) {
+        var serviceAccessToken = authService.getAccessToken();
+        var userToken = ((OAuthUser) user).getAccessToken();
+        if (USER.equals(SimulationConfig.getBearerType())) {
+          builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + userToken);
+          builder = builder.addHeader(SimulationConfig.getHeaderName(), serviceAccessToken);
+        } else if (SERVICE.equals(SimulationConfig.getBearerType())) {
+          builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + serviceAccessToken);
+          builder = builder.addHeader(SimulationConfig.getHeaderName(), userToken);
+        } else {
+          throw new UnknownTokenTypeException(SimulationConfig.getBearerType());
+        }
+      } else {
+        var token = ((OAuthUser) user).getAccessToken();
+        builder = builder.addHeader(HEADER_AUTHORIZATION, BEARER + token);
+      }
+    }
     return builder;
   }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/RetryFailedException.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/exceptions/RetryFailedException.java
@@ -17,16 +17,16 @@
 package io.ryos.rhino.sdk.exceptions;
 
 /**
- * The exception is thrown, whenever a retriable operation fails, that causes the operation will
- * get retried till the attempts reaches maximum number of retries.
+ * The exception will be thrown, when the number of retries exceeded the max number of retries while
+ * executing the spec.
  * <p>
  *
  * @author Erhan Bagdemir
- * @since 1.1.0
+ * @since 1.6.0
  */
-public class RetryableOperationException extends RuntimeException {
+public class RetryFailedException extends RuntimeException {
 
-  public RetryableOperationException(String message) {
-    super(message);
+  public RetryFailedException(Throwable cause) {
+    super(cause);
   }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/monitoring/GrafanaDashboard.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/monitoring/GrafanaDashboard.java
@@ -1,9 +1,8 @@
 package io.ryos.rhino.sdk.monitoring;
 
-import java.io.InputStream;
-
 /**
- * TODO
+ * Grafana dashboard representation. The dashboards will be created by using JSON templates while
+ * starting the application, if Grafana integration is enabled.
  * <p>
  *
  * @author Erhan Bagdemir
@@ -11,8 +10,16 @@ import java.io.InputStream;
  */
 public interface GrafanaDashboard {
 
-  String getDashboard(final String simulationName,
-      final String dashboardTemplate,
-      final String[] scenarios);
-
+  /**
+   * Returns the string representation of the dashboard.
+   * <p>
+   *
+   * @param simulationName The name of the simulation.
+   * @param dashboardTemplate Dashboard template.
+   * @param scenarios A list of scenarios used in dashboards.
+   * @return String representation of the dashboard.
+   */
+  String getDashboard(String simulationName,
+      String dashboardTemplate,
+      String[] scenarios);
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/Measurement.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/Measurement.java
@@ -32,7 +32,21 @@ public interface Measurement {
    * @param stepName The name of the step.
    * @param status HTTP status of the load execution.
    */
-  void measure(final String stepName, final String status);
+  void measure(String stepName, String status);
 
-  void record(final LogEvent event);
+  /**
+   * The {@link LogEvent} will be recorded and stored internally. The
+   * {@link io.ryos.rhino.sdk.runners.EventDispatcher} will then dispatch the persisted events to
+   * the instances which process these events.
+   * <p>
+   *
+   * @param event log event.
+   */
+  void record(LogEvent event);
+
+  /**
+   * Purge the backing data structure by deleting all the events stored.
+   * <p>
+   */
+  void purge();
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/MeasurementImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/MeasurementImpl.java
@@ -38,7 +38,6 @@ public class MeasurementImpl implements Measurement {
 
   @Override
   public void measure(final String stepName, final String status) {
-
     if (events.isEmpty()) {
 
       final ScenarioEvent simLog = new ScenarioEvent();
@@ -50,7 +49,7 @@ public class MeasurementImpl implements Measurement {
       simLog.userId = userId;
       simLog.status = status;
 
-      events.add(simLog);
+      addEvent(simLog);
 
     } else {
 
@@ -67,8 +66,12 @@ public class MeasurementImpl implements Measurement {
       simLog.userId = userId;
       simLog.status = status;
 
-      events.add(simLog);
+      addEvent(simLog);
     }
+  }
+
+  private synchronized void addEvent(ScenarioEvent event) {
+    events.add(event);
   }
 
   public void record(final LogEvent event) {
@@ -77,5 +80,9 @@ public class MeasurementImpl implements Measurement {
 
   public List<LogEvent> getEvents() {
     return events;
+  }
+
+  public synchronized void purge() {
+    events.clear();
   }
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/StdoutReporter.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/reporting/StdoutReporter.java
@@ -121,7 +121,6 @@ public class StdoutReporter extends AbstractActor {
   }
 
   private void persist(final ScenarioEvent logEvent) {
-
     String countKey = String.format("Count/%s/%s/%s",
         logEvent.scenario,
         logEvent.step,

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/EventDispatcher.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/runners/EventDispatcher.java
@@ -91,15 +91,19 @@ public class EventDispatcher {
     }
   }
 
-  public void dispatchEvents(final MeasurementImpl measurement) {
-    measurement.getEvents().forEach(e -> {
-      loggerActor.tell(e, ActorRef.noSender());
-      stdOutReptorter.tell(e, ActorRef.noSender());
+  public void dispatchEvents(MeasurementImpl measurement) {
+    try {
+      measurement.getEvents().forEach(e -> {
+        loggerActor.tell(e, ActorRef.noSender());
+        stdOutReptorter.tell(e, ActorRef.noSender());
 
-      if (simulationMetadata.isEnableInflux()) {
-        influxActor.tell(e, ActorRef.noSender());
-      }
-    });
+        if (simulationMetadata.isEnableInflux()) {
+          influxActor.tell(e, ActorRef.noSender());
+        }
+      });
+    } finally {
+      measurement.purge();
+    }
   }
 
   public void stop() {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/AbstractSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/AbstractSpec.java
@@ -23,24 +23,26 @@ package io.ryos.rhino.sdk.specs;
  * @author Erhan Bagdemir
  * @since 1.1.0
  */
-public class AbstractSpec implements Spec {
+public abstract class AbstractSpec implements Spec {
 
   private String enclosingSpec;
   private String measurementPoint;
   private boolean measurementEnabled = true;
+  private boolean cumulativeMeasurement = false;
 
   AbstractSpec(String measurement) {
     this.measurementPoint = measurement;
   }
 
   @Override
-  public boolean isMeasurementEnabled() {
-    return measurementEnabled;
+  public Spec noMeasurement() {
+    this.measurementEnabled = false;
+    return this;
   }
 
   @Override
-  public Spec noMeasurement() {
-    this.measurementEnabled = false;
+  public Spec cumulativeMeasurement() {
+    this.cumulativeMeasurement = true;
     return this;
   }
 
@@ -58,4 +60,15 @@ public class AbstractSpec implements Spec {
   public void setTestName(String testName) {
     this.enclosingSpec = testName;
   }
+
+  @Override
+  public boolean isCumulativeMeasurement() {
+    return cumulativeMeasurement;
+  }
+
+  @Override
+  public boolean isMeasurementEnabled() {
+    return measurementEnabled;
+  }
+
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/AbstractSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/AbstractSpec.java
@@ -23,7 +23,7 @@ package io.ryos.rhino.sdk.specs;
  * @author Erhan Bagdemir
  * @since 1.1.0
  */
-public abstract class AbstractSpec implements Spec {
+public abstract class AbstractSpec implements MeasurableSpec {
 
   private String enclosingSpec;
   private String measurementPoint;

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpec.java
@@ -10,7 +10,7 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public interface HttpSpec extends RetriableSpec<HttpSpec, HttpResponse> {
+public interface HttpSpec extends RetriableSpec<MeasurableSpec, HttpResponse>, MeasurableSpec {
 
   enum Method {GET, HEAD, PUT, POST, OPTIONS, DELETE, PATCH}
 

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpecImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/HttpSpecImpl.java
@@ -143,7 +143,7 @@ public class HttpSpecImpl extends AbstractSpec implements HttpSpec, HttpConfigSp
   }
 
   @Override
-  public HttpSpec retryIf(final Predicate<HttpResponse> predicate, final int numOfRetries) {
+  public MeasurableSpec retryIf(final Predicate<HttpResponse> predicate, final int numOfRetries) {
     this.retryInfo = new RetryInfo(predicate, numOfRetries);
     return this;
   }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/MeasurableSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/MeasurableSpec.java
@@ -14,23 +14,30 @@
   limitations under the License.
 */
 
-package io.ryos.rhino.sdk.reporting;
+package io.ryos.rhino.sdk.specs;
 
-public class ScenarioEvent extends LogEvent {
-  public String status;
-  public String step;
+/**
+ * Retriable spec is the DSL spec which is to be retried if predicate turns true.
+ * <p>
+ *
+ * @author Erhan Bagdemir
+ * @since 1.1.0
+ */
+public interface MeasurableSpec extends Spec {
 
-  @Override
-  public String toString() {
-    return "ScenarioEvent{" +
-        "status='" + status + '\'' +
-        ", step='" + step + '\'' +
-        ", username='" + username + '\'' +
-        ", userId='" + userId + '\'' +
-        ", scenario='" + scenario + '\'' +
-        ", start=" + start +
-        ", end=" + end +
-        ", elapsed=" + elapsed +
-        '}';
-  }
+  /**
+   * Disables the measurement recording.
+   * <p>
+   *
+   * @return {@link HttpConfigSpec} instance.
+   */
+  Spec noMeasurement();
+
+  /**
+   * Cumulative measurement.
+   * <p>
+   *
+   * @return {@link HttpConfigSpec} instance.
+   */
+  Spec cumulativeMeasurement();
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/RetriableSpec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/RetriableSpec.java
@@ -2,7 +2,24 @@ package io.ryos.rhino.sdk.specs;
 
 import java.util.function.Predicate;
 
-public interface RetriableSpec<R extends Spec, T> extends Spec {
+/**
+ * Retriable spec is the DSL spec which is to be retried if predicate turns true.
+ * <p>
+ *
+ * @param <R> Return type.
+ * @param <T> Predicate's type.
+ * @author Erhan Bagdemir
+ * @since 1.1.0
+ */
+public interface RetriableSpec<R extends MeasurableSpec, T> extends Spec {
 
+  /**
+   * Retries, if the predicate is true and the current attempt less then numOfRetries.
+   * <p>
+   *
+   * @param predicate If predicate turns true, then the spec will be repeated.
+   * @param numOfRetries Number of retries.
+   * @return The spec instance which is to be repeated.
+   */
   R retryIf(Predicate<T> predicate, int numOfRetries);
 }

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/Spec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/Spec.java
@@ -28,22 +28,6 @@ public interface Spec {
   }
 
   /**
-   * Disables the measurement recording.
-   * <p>
-   *
-   * @return {@link HttpConfigSpec} instance.
-   */
-  Spec noMeasurement();
-
-  /**
-   * Cumulative measurement.
-   * <p>
-   *
-   * @return {@link HttpConfigSpec} instance.
-   */
-  Spec cumulativeMeasurement();
-
-  /**
    * Whether the measurement is enabled.
    * <p>
    *

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/Spec.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/specs/Spec.java
@@ -36,12 +36,28 @@ public interface Spec {
   Spec noMeasurement();
 
   /**
+   * Cumulative measurement.
+   * <p>
+   *
+   * @return {@link HttpConfigSpec} instance.
+   */
+  Spec cumulativeMeasurement();
+
+  /**
    * Whether the measurement is enabled.
    * <p>
    *
-   * @return True if is measurement enabled.
+   * @return True if measurement is enabled.
    */
   boolean isMeasurementEnabled();
+
+  /**
+   * Whether the measurement is cumulative.
+   * <p>
+   *
+   * @return True if cumulative measurement is enabled.
+   */
+  boolean isCumulativeMeasurement();
 
   /**
    * The name of the spec. It is the step name in scenario counterpart.

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/FluxTimingsTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/FluxTimingsTest.java
@@ -23,10 +23,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.ryos.rhino.sdk.dsl.HttpSpecMaterializer;
-import io.ryos.rhino.sdk.runners.EventDispatcher;
 import org.asynchttpclient.Dsl;
-import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.filter.ThrottleRequestFilter;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +68,5 @@ public class FluxTimingsTest {
           System.out.println("completed");
         })
         .blockLast();
-
-    System.out.println("After flux");
   }
 }

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitSimulation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Ryos.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ryos.rhino.sdk;
+
+import static io.ryos.rhino.sdk.specs.HttpSpec.from;
+import static io.ryos.rhino.sdk.specs.Spec.http;
+import static io.ryos.rhino.sdk.specs.UploadStream.file;
+
+import io.ryos.rhino.sdk.annotations.Dsl;
+import io.ryos.rhino.sdk.annotations.Provider;
+import io.ryos.rhino.sdk.annotations.Runner;
+import io.ryos.rhino.sdk.annotations.Simulation;
+import io.ryos.rhino.sdk.annotations.UserProvider;
+import io.ryos.rhino.sdk.dsl.LoadDsl;
+import io.ryos.rhino.sdk.dsl.Start;
+import io.ryos.rhino.sdk.providers.OAuthUserProvider;
+import io.ryos.rhino.sdk.providers.UUIDProvider;
+import io.ryos.rhino.sdk.runners.ReactiveHttpSimulationRunner;
+
+/**
+ */
+@Simulation(name = "Reactive Monitor Test")
+@Runner(clazz = ReactiveHttpSimulationRunner.class)
+public class ReactiveMonitorWaitSimulation {
+
+  private static final String FILES_ENDPOINT = "http://localhost:8089/api/files";
+  private static final String MONITOR_ENDPOINT = "http://localhost:8089/api/monitor";
+  private static final String X_REQUEST_ID = "X-Request-Id";
+  private static final String X_API_KEY = "X-Api-Key";
+
+  @UserProvider(region = "US")
+  private OAuthUserProvider userProvider;
+
+  @Provider(factory = UUIDProvider.class)
+  private UUIDProvider uuidProvider;
+
+  @Dsl(name = "Upload File")
+  public LoadDsl singleTestDsl() {
+    return Start
+        .dsl()
+        .run(http("Upload")
+            .header(c -> from(X_REQUEST_ID, "Rhino-" + uuidProvider.take()))
+            .header(X_API_KEY, SimulationConfig.getApiKey())
+            .auth()
+            .upload(() -> file("classpath:///test.txt"))
+            .endpoint((c) -> FILES_ENDPOINT)
+            .put()
+            .saveTo("result"))
+        .run(http("Monitor")
+            .header(c -> from(X_REQUEST_ID, "Rhino-" + uuidProvider.take()))
+            .header(X_API_KEY, SimulationConfig.getApiKey())
+            .auth()
+            .endpoint((c) -> MONITOR_ENDPOINT)
+            .get()
+            .saveTo("result")
+        .retryIf((httpResponse) -> httpResponse.getStatusCode() != 200, 2)
+            .cumulativeMeasurement());
+  }
+}

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitSimulation.java
@@ -67,7 +67,6 @@ public class ReactiveMonitorWaitSimulation {
             .endpoint((c) -> MONITOR_ENDPOINT)
             .get()
             .saveTo("result")
-        .retryIf((httpResponse) -> httpResponse.getStatusCode() != 200, 2)
-            .cumulativeMeasurement());
+            .retryIf((httpResponse) -> httpResponse.getStatusCode() != 200, 2));
   }
 }

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/ReactiveMonitorWaitTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Ryos.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ryos.rhino.sdk;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ */
+public class ReactiveMonitorWaitTest {
+
+  private static final String SIM_NAME = "Reactive Monitor Test";
+  private static final String PROPERTIES_FILE = "classpath:///rhino.properties";
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(options().port(8089)
+      .jettyAcceptors(2)
+      .jettyAcceptQueueSize(100)
+      .containerThreads(100));
+
+  @Test
+  public void testReactiveBasicHttp() throws InterruptedException {
+    stubFor(WireMock.post(urlEqualTo("/token"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withBody("{\"access_token\": \"abc123\", \"refresh_token\": \"abc123\"}")));
+
+    stubFor(WireMock.put(urlEqualTo("/api/files"))
+
+        .willReturn(aResponse()
+            .withFixedDelay(1000)
+            .withStatus(201)));
+
+    stubFor(WireMock.get(urlEqualTo("/api/monitor"))
+        .willReturn(aResponse()
+            .withFixedDelay(5000)
+            .withStatus(404)));
+
+    Simulation.create(PROPERTIES_FILE, SIM_NAME).start();
+
+    Thread.sleep(5000L);
+  }
+}

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/RetrySpecTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/RetrySpecTest.java
@@ -40,7 +40,6 @@ public class RetrySpecTest {
     Mono.fromFuture(client.executeRequest(requestBuilder).toCompletableFuture())
         .map(r -> {
           if (r.getStatusCode() == 404) {
-            System.out.println(404);
             throw new RuntimeException();
           }
 

--- a/rhino-core/src/test/resources/rhino.properties
+++ b/rhino-core/src/test/resources/rhino.properties
@@ -23,9 +23,10 @@ db.influx.username=
 db.influx.password=
 
 # Number of threads will be used to run scenarios.
-runner.parallelisim=10
+runner.parallelisim=1
 
-reactor.maxConnections=1
+http.maxConnections=10
+http.readTimeout=15000
 
 # node name
 node=docker-dev


### PR DESCRIPTION
@luxmeter 

Cumulative measurements are to be associated with retriable specs, e.g HttpSpec. 
In case of retries, if  cumulative measurement is enabled by calling cumulativeMeasurement() on Spec instance, then the framework will measure the total time elapsed beginning from the first attempt, until the last attempt. The reporting will then show all repeated executions as one. In other frameworks this feature is called as "group/grouping". 

Without cumulative measurement, 

```java
        .run(http("Monitor")
            .header(c -> from(X_REQUEST_ID, "Rhino-" + uuidProvider.take()))
            .header(X_API_KEY, SimulationConfig.getApiKey())
            .auth()
            .endpoint((c) -> MONITOR_ENDPOINT)
            .get()
            .saveTo("result")
            .retryIf((httpResponse) -> httpResponse.getStatusCode() != 200, 2));
```

and max. retry with 2, the reporting will look as follows: 

```
==========================================================================
-- Number of executions --------------------------------------------------
> Upload File      Upload                                201 1
> Upload File      Monitor                               200 1
> Upload File      Monitor                               404 1
-- Response Time ---------------------------------------------------------
> Upload File      Monitor                               404 107 ms
> Upload File      Monitor                               200 104 ms
> Upload File      Upload                                201 158 ms

==========================================================================
                             Average Response Time       123 ms
                                     Total Request         3 
==========================================================================
```
Every retry will be recorded. However, if you enable the cumulative measurement, 
```java
        .run(http("Monitor")
            .header(c -> from(X_REQUEST_ID, "Rhino-" + uuidProvider.take()))
            .header(X_API_KEY, SimulationConfig.getApiKey())
            .auth()
            .endpoint((c) -> MONITOR_ENDPOINT)
            .get()
            .saveTo("result")
            .retryIf((httpResponse) -> httpResponse.getStatusCode() != 200, 2)
        .cumulativeMeasurement());
```
the monitoring attempts will be reported as one:
```
==========================================================================
-- Number of executions --------------------------------------------------
> Upload File      Upload                                201 1
> Upload File      Monitor                               200 1
-- Response Time ---------------------------------------------------------
> Upload File      Monitor                               200 217 ms
> Upload File      Upload                                201 160 ms

==========================================================================
                             Average Response Time       188 ms
                                     Total Request         2 
==========================================================================

```


Fixes #93 