### PR TITLE
refactored ramp up and removed waitResult()

### DIFF
--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/RampupInfo.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/RampupInfo.java
@@ -3,15 +3,24 @@ package io.ryos.rhino.sdk;
 import java.time.Duration;
 
 public class RampupInfo {
-
   private long startRps;
   private long targetRps;
   private Duration duration;
+  private static final RampupInfo NONE = new RampupInfo(-1, -1, Duration.ZERO);
 
-  public RampupInfo(final long startRps, final long targetRps, final Duration duration) {
+  private RampupInfo(final long startRps, final long targetRps, final Duration duration) {
     this.startRps = startRps;
     this.targetRps = targetRps;
     this.duration = duration;
+  }
+
+  public static RampupInfo ofDefault(final long startRps, final long targetRps,
+      final Duration duration) {
+    return new RampupInfo(startRps, targetRps, duration);
+  }
+
+  public static RampupInfo none() {
+    return NONE;
   }
 
   public long getStartRps() {

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/annotations/RampUp.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/annotations/RampUp.java
@@ -23,7 +23,7 @@ public @interface RampUp {
    *
    * @return Start RPS.
    */
-  long startRps() default 0;
+  long startRps() default 1;
 
   /**
    * Target request-per-second.

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpDsl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/HttpDsl.java
@@ -37,10 +37,6 @@ public interface HttpDsl extends RetriableDsl<HttpResponse>,
     GET, HEAD, PUT, POST, OPTIONS, DELETE, PATCH
   }
 
-  HttpDsl waitResult();
-
-  boolean isWaitResult();
-
   // Getters
   Method getMethod();
 

--- a/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/impl/HttpDslImpl.java
+++ b/rhino-core/src/main/java/io/ryos/rhino/sdk/dsl/impl/HttpDslImpl.java
@@ -58,7 +58,6 @@ public class HttpDslImpl extends AbstractSessionDslItem implements HttpDsl, Http
   private Supplier<User> userSupplier;
   private RetryInfo retryInfo;
   private HttpResponse response;
-  private boolean waitResult = false;
 
   /**
    * Creates a new {@link HttpDslImpl}.
@@ -312,12 +311,6 @@ public class HttpDslImpl extends AbstractSessionDslItem implements HttpDsl, Http
   }
 
   @Override
-  public HttpDsl waitResult() {
-    this.waitResult = true;
-    return this;
-  }
-
-  @Override
   public List<Function<UserSession, Entry<String, List<String>>>> getHeaders() {
     return headers;
   }
@@ -375,10 +368,6 @@ public class HttpDslImpl extends AbstractSessionDslItem implements HttpDsl, Http
   @Override
   public RetryInfo getRetryInfo() {
     return retryInfo;
-  }
-
-  public boolean isWaitResult() {
-    return waitResult;
   }
 
   @Override

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/RampUpSimulationTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/RampUpSimulationTest.java
@@ -1,0 +1,48 @@
+package io.ryos.rhino.sdk;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.ryos.rhino.sdk.annotations.UserProvider;
+import io.ryos.rhino.sdk.providers.OAuthUserProvider;
+import io.ryos.rhino.sdk.simulations.RampUpSimulation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RampUpSimulationTest {
+  private static final String PROPERTIES_FILE = "classpath:///rhino.properties";
+  private static final int PORT = 8089;
+  private WireMockServer wmServer;
+
+  @UserProvider
+  private OAuthUserProvider userProvider;
+
+  @Before
+  public void setUp() {
+    wmServer = new WireMockServer(wireMockConfig().port(PORT)
+        .jettyAcceptors(2)
+        .jettyAcceptQueueSize(100)
+        .containerThreads(100));
+    wmServer.start();
+  }
+
+  @After
+  public void tearDown() {
+    wmServer.stop();
+  }
+
+  @Test
+  public void test() {
+    WireMock.configureFor("localhost", PORT);
+
+    wmServer.stubFor(WireMock.post(urlEqualTo("/token"))
+        .willReturn(aResponse().withStatus(200)
+            .withBody("{\"access_token\": \"abc123\", \"refresh_token\": \"abc123\"}")));
+
+    Simulation.getInstance(PROPERTIES_FILE, RampUpSimulation.class).start();
+  }
+}

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/runners/RampupTest.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/runners/RampupTest.java
@@ -1,170 +1,134 @@
 package io.ryos.rhino.sdk.runners;
 
-import static java.time.temporal.ChronoUnit.MILLIS;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.RequestBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 class RampupTest {
-  private static final Logger LOG = LoggerFactory.getLogger(RampupTest.class);
+  private static WireMockServer SERVER;
+  private static AsyncHttpClient ASYNC_CLIENT;
 
-  private static class VirtualClock {
-    Instant start = Instant.now();
-    Instant current = start;
+  @BeforeAll
+  static void beforeAll() {
+    SERVER = new WireMockServer(wireMockConfig().port(8088)
+        .jettyAcceptors(2)
+        .jettyAcceptQueueSize(100)
+        .containerThreads(100));
+    SERVER.start();
+    WireMock.configureFor("localhost", SERVER.port());
+    ASYNC_CLIENT = Dsl.asyncHttpClient();
+  }
 
-    public VirtualClock() {
-    }
-
-    public VirtualClock(final Instant start) {
-      this.start = start;
-    }
-
-    public Instant getStartTime() {
-      return start;
-    }
-
-    public Instant advance(Duration duration) {
-      current = current.plus(duration);
-      return current;
-    }
-
-    public Instant getCurrentTime() {
-      return current;
-    }
-
-    public Duration getAdvancedTime() {
-      return Duration.of(start.until(current, MILLIS), MILLIS);
-    }
+  @BeforeEach
+  void beforeEach() {
+    WireMock.stubFor(WireMock.get(urlEqualTo("/"))
+        .willReturn(aResponse()
+            .withStatus(200)));
   }
 
   @Test
-  void testConcurrentRequestsAtTheSameTime() throws InterruptedException {
-    Instant now = Instant.now();
-    VirtualClock clock = new VirtualClock(now);
-    VirtualClock helperClock = new VirtualClock(now);
-    int startRps = 1;
-    int targetRps = 30;
-    Duration duration = Duration.of(30, ChronoUnit.SECONDS);
-    Rampup rampup = new Rampup(clock.getStartTime(),
-        startRps, targetRps, duration);
-
-    final Duration[] previousTick = new Duration[] {Duration.ZERO};
-    Supplier<Duration> expectedTick = () -> {
-      Duration tick = getTick(helperClock, startRps, targetRps, duration);
-      helperClock.advance(tick);
-      previousTick[0] = previousTick[0].plus(tick);
-      return previousTick[0];
-    };
-
-    while (helperClock.getAdvancedTime().minus(duration).isNegative()) {
-      assertThat(rampup.getTimeToWait(clock::getCurrentTime), is(expectedTick.get()));
-    }
-  }
-
-  @Test
-  void testConcurrentRequestsAtDifferentTimes() {
-    Instant now = Instant.now();
-    VirtualClock clock = new VirtualClock(now);
-    int startRps = 1;
-    int targetRps = 10;
-
-    Duration duration = Duration.of(10, ChronoUnit.SECONDS);
-    Rampup rampup = new Rampup(clock.getStartTime(),
-        startRps, targetRps, duration);
-
-    assertThat(rampup.getTimeToWait(clock::getCurrentTime), is(Duration.of(1000, MILLIS)));
-    // between the tick generation some delay happened (2s) - the time has to be corrected and the caller should go on immediately (0 delay)
-    clock.advance(Duration.of(2000, MILLIS));
-    assertThat(rampup.getTimeToWait(clock::getCurrentTime), is(Duration.of(0, MILLIS)));
-    // however if the next requester asks at the same time, it has to wait
-    assertThat("Tick should be greater than 0",
-        rampup.getTimeToWait(clock::getCurrentTime).toMillis() > 0);
-  }
-
-  @Test
-  void testWithinFlux() {
-    Instant now = Instant.now();
-    Rampup instance = new Rampup(now, 1, 10, Duration.of(10, SECONDS));
-    Flux<Integer> flux = Flux.range(1, 100)
-        .repeat(1)
-        .flatMap(n -> Mono.just(n).delayElement(instance.getTimeToWait()))
+  void rampup() {
+    Duration duration = Duration.ofSeconds(10);
+    var rampup = new Rampup(1, 10, duration);
+    Supplier<Flux<Map.Entry<Integer, Integer>>>
+        flux = () -> Flux.fromStream(IntStream.range(1, 56).boxed())
+        .take(duration)
+        .flatMap(i ->
+            // ruft onNext auf flatMap auf
+            rampup.rampUp(i).flatMap(v -> Mono.fromCompletionStage(
+                ASYNC_CLIENT.executeRequest(
+                    new RequestBuilder()
+                        .setMethod("GET")
+                        .setUrl(SERVER.baseUrl())
+                        .build())
+                    .toCompletableFuture()
+                    .thenApply(response -> Map.entry(i, response.getStatusCode())))))
         .log();
-    StepVerifier.setDefaultTimeout(Duration.of(1, SECONDS));
-    StepVerifier.withVirtualTime(() -> flux)
+    flux.get().subscribe();
+    StepVerifier.setDefaultTimeout(Duration.ofSeconds(3));
+    StepVerifier.withVirtualTime(flux)
         .expectSubscription()
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(1)
+        .expectNextCount(1)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(2, 3)
+        .expectNextCount(1)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(4, 5, 6)
+        .expectNextCount(2)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(7, 8, 9, 10)
+        .expectNextCount(3)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(11, 12, 13, 14, 15)
+        .expectNextCount(4)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(16, 17, 18, 19, 20, 21)
+        .expectNextCount(5)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(22, 23, 24, 25, 26, 27, 28)
+        .expectNextCount(6)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(29, 30, 31, 32, 33, 34, 35, 36)
+        .expectNextCount(7)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(37, 38, 39, 40, 41, 42, 43, 44, 45)
+        .expectNextCount(8)
         .thenAwait(Duration.of(1, SECONDS))
-        .expectNext(46, 47, 48, 49, 50, 51, 52, 53, 54, 55)
-        .thenAwait(Duration.of(20, SECONDS))
-        .expectNextCount(45 + 100) // get the rest
-        .expectComplete()
-        .verify();
+        .expectNextCount(9)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(10)
+        .thenCancel();
   }
 
   @Test
-  void testConstantThrottling() {
-    Instant now = Instant.now();
-    Rampup instance = new Rampup(now, 2, 2, Duration.of(6, SECONDS));
-    Flux<Integer> flux = Flux.range(1, 6)
-        .flatMap(n -> Mono.just(n).delayElement(instance.getTimeToWait()))
-        .log();
-    StepVerifier.setDefaultTimeout(Duration.of(1, SECONDS));
-    StepVerifier.withVirtualTime(() -> flux)
+  void constRps() {
+    Duration duration = Duration.ofSeconds(10);
+    var rampup = new Rampup(1, 1, duration);
+    Supplier<Flux<Integer>>
+        flux = () -> Flux.fromStream(IntStream.range(1, 100).boxed())
+        .flatMap(rampup::rampUp)
+        .flatMap(i ->
+            // ruft onNext auf flatMap auf
+            Mono.fromCompletionStage(
+                ASYNC_CLIENT.executeRequest(
+                    new RequestBuilder()
+                        .setMethod("GET")
+                        .setUrl(SERVER.baseUrl())
+                        .build())
+                    .toCompletableFuture()
+                    .thenApply(response -> Map.entry(i, response.getStatusCode()))))
+        .map(Map.Entry::getKey)
+        .take(duration);
+    StepVerifier.setDefaultTimeout(Duration.ofSeconds(3));
+    StepVerifier.withVirtualTime(flux)
         .expectSubscription()
-        .expectNoEvent(Duration.of(300, MILLIS))
-        .thenAwait(Duration.of(200, MILLIS))
-        .expectNext(1)
-        .thenAwait(Duration.of(500, MILLIS))
-        .expectNext(2)
-        .thenAwait(Duration.of(500, MILLIS))
-        .expectNext(3)
-        .thenAwait(Duration.of(500, MILLIS))
-        .expectNext(4)
-        .thenAwait(Duration.of(500, MILLIS))
-        .expectNext(5)
-        .thenAwait(Duration.of(500, MILLIS))
-        .expectNext(6)
-        .expectComplete()
-        .verify();
-  }
-
-  double getRps(VirtualClock clock, double startRps, double targetRps, Duration duration) {
-    double slope = (targetRps - startRps) / duration.toSeconds();
-    var rps = startRps + (slope * (clock.getAdvancedTime().toMillis() / 1e3D));
-    return rps;
-  }
-
-  Duration getTick(VirtualClock clock, double startRps, double targetRps, Duration duration) {
-    var rps = getRps(clock, startRps, targetRps, duration);
-    var tick = (1 / rps) * 1e3D;
-    return Duration.of((long) tick, MILLIS);
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .expectNextCount(1)
+        .thenAwait(Duration.of(1, SECONDS))
+        .thenCancel();
   }
 }

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/ForEachNestedSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/ForEachNestedSimulation.java
@@ -35,9 +35,9 @@ import io.ryos.rhino.sdk.dsl.DslBuilder;
 import io.ryos.rhino.sdk.users.repositories.OAuthUserRepositoryFactoryImpl;
 import java.util.UUID;
 
-@Simulation(name = "Reactive Multi-User Test")
+@Simulation(name = "Reactive Multi-User Test", durationInMins = 1)
 @UserRepository(factory = OAuthUserRepositoryFactoryImpl.class)
-@RampUp(startRps = 0, targetRps = 100)
+@RampUp(startRps = 1, targetRps = 100)
 public class ForEachNestedSimulation {
 
   private static final String DISCOVERY_ENDPOINT = getEndpoint("discovery");
@@ -60,7 +60,6 @@ public class ForEachNestedSimulation {
                     .endpoint(DISCOVERY_ENDPOINT)
                     .get())
                 //                    .collect("list.outer")
-                //                    .waitResult())
                 .forEach(in(session("j")).exec(j ->
                     dsl()
                         .run(collect(http("Discovery Request -2")
@@ -82,6 +81,6 @@ public class ForEachNestedSimulation {
             .auth()
             .endpoint(DISCOVERY_ENDPOINT)
             .get()
-            .saveTo("result").waitResult());
+            .saveTo("result"));
   }
 }

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/RampUpSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/RampUpSimulation.java
@@ -1,0 +1,26 @@
+package io.ryos.rhino.sdk.simulations;
+
+import static io.ryos.rhino.sdk.dsl.DslBuilder.dsl;
+import static io.ryos.rhino.sdk.dsl.MaterializableDslItem.http;
+
+import io.ryos.rhino.sdk.annotations.Dsl;
+import io.ryos.rhino.sdk.annotations.RampUp;
+import io.ryos.rhino.sdk.annotations.Simulation;
+import io.ryos.rhino.sdk.annotations.UserRepository;
+import io.ryos.rhino.sdk.dsl.DslBuilder;
+import io.ryos.rhino.sdk.users.repositories.OAuthUserRepositoryFactoryImpl;
+import org.junit.jupiter.api.Disabled;
+
+@Disabled
+@Simulation(name = "Ramp up simulation", durationInMins = 2)
+@UserRepository(factory = OAuthUserRepositoryFactoryImpl.class)
+@RampUp(startRps = 10, targetRps = 200)
+public class RampUpSimulation {
+  @Dsl(name = "Call google")
+  public DslBuilder testRampUp() {
+    return dsl()
+        .run(http("GET google.de")
+            .endpoint("https://google.de")
+            .get());
+  }
+}

--- a/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/ReactiveMonitorWaitSimulation.java
+++ b/rhino-core/src/test/java/io/ryos/rhino/sdk/simulations/ReactiveMonitorWaitSimulation.java
@@ -55,8 +55,7 @@ public class ReactiveMonitorWaitSimulation {
             .upload(() -> file("classpath:///test.txt"))
             .endpoint(session -> FILES_ENDPOINT)
             .put()
-            .saveTo("result")
-            .waitResult())
+            .saveTo("result"))
         .run(http("Monitor")
             .header(session -> headerValue(X_REQUEST_ID, "Rhino-" + uuidProvider.take()))
             .header(X_API_KEY, SimulationConfig.getApiKey())
@@ -64,7 +63,6 @@ public class ReactiveMonitorWaitSimulation {
             .endpoint(session -> MONITOR_ENDPOINT)
             .get()
             .saveTo("result")
-            .waitResult()
             .retryIf(response -> response.getStatusCode() != 200, 2)
         );
   }

--- a/rhino-core/src/test/resources/log4j2.xml
+++ b/rhino-core/src/test/resources/log4j2.xml
@@ -12,7 +12,7 @@
         <Logger name="io.ryos.rhino" level="debug" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Logger name="io.ryos.rhino.sdk.runners.Rampup" level="debug" additivity="false">
+        <Logger name="io.ryos.rhino.sdk.runners.Rampup" level="info" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>


### PR DESCRIPTION
refactored rampup code. also more rps are possible since no tick is used anymore.
 now it seems like there is no overhead when you use the annotation - i tested a simluation without the annotation and with the annotation setting a high start and end target rps. i didn't notice a difference.

however i noticed there is a cap somewhere between 20rps on my machine. don't know what causes this.

**removed** waitResult method - i didn't see why it would be needed.